### PR TITLE
lightsaml/lightsaml is abandoned, switching to litesaml/lightsaml

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "lightsaml/lightsaml": "^1.0"
+        "litesaml/lightsaml": "^1.0"
     }
 }


### PR DESCRIPTION
Hey there, thanks for the nice pam script. While trying it out and running composer, I found out lightsaml/lightsaml is abandoned and is replaced by litesaml/lightsaml. This should get rid of the warning.